### PR TITLE
Background audio resume ability added

### DIFF
--- a/ios/RNSoundPlayer.m
+++ b/ios/RNSoundPlayer.m
@@ -96,6 +96,7 @@ RCT_EXPORT_METHOD(setMixAudio:(BOOL) on) {
     
     if (on) {
         [session setCategory: AVAudioSessionCategoryPlayback withOptions:AVAudioSessionCategoryOptionMixWithOthers error:nil];
+        [session setActive:false withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
     } else {
         [session setCategory: AVAudioSessionCategoryPlayback withOptions:0 error:nil];
     }


### PR DESCRIPTION
**Technical Modification** 

- Notify the other Audio Sessions the deactivation of the main react-native-sound-player music track. Which enables other players to resume whatever was playing